### PR TITLE
Update CORS configuration to allow requests from the new frontend URL🔒🔒

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ dotenv.config();
 const app = express();
 
 app.use(cors({
-    origin: 'http://localhost:5173',
+    origin: ['http://localhost:5173', 'https://cbc-frontend-eta.vercel.app'],
     methods: ['GET', 'POST', 'PUT', 'DELETE'], // Allow these HTTP methods
     credentials: true // Allow cookies to be sent with requests
 }));


### PR DESCRIPTION
This pull request includes a change to the `index.js` file to allow cross-origin requests from an additional origin.

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L17-R17): Modified the `cors` configuration to include 'https://cbc-frontend-eta.vercel.app' in the allowed origins.